### PR TITLE
Include allowed tags parameter in striptags

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -336,12 +336,12 @@ module.exports = function (Twig) {
             return Twig.lib.vsprintf(value, params);
         },
 
-        striptags: function(value) {
+        striptags: function(value, allowed) {
             if (value === undefined || value === null){
                 return;
             }
 
-            return Twig.lib.strip_tags(value);
+            return Twig.lib.strip_tags(value, allowed);
         },
 
         escape: function(value, params) {


### PR DESCRIPTION
Striptags filter is currenty ignoring allowed_tags parameter. This patch should fix it.